### PR TITLE
Create sigrid-pullrequest.yml

### DIFF
--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -1,0 +1,15 @@
+name: sigrid-pullrequest
+on: [pull_request]
+
+jobs:
+  sigridci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Download Sigrid CI
+        run: "git clone https://github.com/Software-Improvement-Group/sigridci.git sigridci"
+      - name: "Run Sigrid CI" 
+        env:
+          SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
+        run: "./sigridci/sigridci/sigridci.py --customer hhsproject2 --system 2023-Projectgroep-H-1-SE-4d --source ."


### PR DESCRIPTION
De files in patch-2 en patch-3 zijn nodig voor de inrichting van Sigrid. In de huidige patch zit nog een kleine fout: de key in de file moet nog worden hernoemd van SIGRID_CI_TOKEN naar SIGRID_CI_TOKEN_SALIH.